### PR TITLE
format everything of the applications

### DIFF
--- a/src/erl_tidy_prv_fmt.erl
+++ b/src/erl_tidy_prv_fmt.erl
@@ -42,9 +42,9 @@ format_error(Reason) ->
 
 format_apps(Opts, Apps) ->
     lists:foreach(fun(AppInfo) ->
-                          SrcDir = filename:join(rebar_app_info:dir(AppInfo), "src"),
+                          AppDir = rebar_app_info:dir(AppInfo),
                           rebar_log:log(info, "Formating ~s...", [rebar_app_info:name(AppInfo)]),
-                          erl_tidy:dir(SrcDir, Opts)
+                          erl_tidy:dir(AppDir, Opts)
                   end, Apps).
 
 fmt_opts() ->

--- a/src/erl_tidy_prv_fmt.erl
+++ b/src/erl_tidy_prv_fmt.erl
@@ -44,7 +44,10 @@ format_apps(Opts, Apps) ->
     lists:foreach(fun(AppInfo) ->
                           AppDir = rebar_app_info:dir(AppInfo),
                           rebar_log:log(info, "Formating ~s...", [rebar_app_info:name(AppInfo)]),
-                          erl_tidy:dir(AppDir, Opts)
+                          SrcDirs = [Dir || InAppDir <- ["src", "test", "include"],
+                                            Dir <- [filename:join(AppDir, InAppDir)],
+                                            filelib:is_dir(Dir)],
+                          lists:foreach(fun(Dir) -> erl_tidy:dir(Dir, Opts) end, SrcDirs)
                   end, Apps).
 
 fmt_opts() ->


### PR DESCRIPTION
Format everything of the applications instead of just formatting the source directory.  This will include formatting of `include` and `test` directories.