### PR TITLE
Expose `backups` opt as stdin argument

### DIFF
--- a/src/erl_tidy.erl
+++ b/src/erl_tidy.erl
@@ -39,17 +39,25 @@
 
 -module(erl_tidy).
 
--export([dir/0, dir/1, dir/2, file/1, file/2, module/1, module/2]).
+-export([dir/0,
+         dir/1,
+         dir/2,
+         file/1,
+         file/2,
+         module/1,
+         module/2]).
 
 -include_lib("kernel/include/file.hrl").
 
 -define(DEFAULT_BACKUP_SUFFIX, ".bak").
+
 -define(DEFAULT_DIR, "").
+
 -define(DEFAULT_REGEXP, ".*\\.erl$").
 
 %% =====================================================================
 
--type options()  :: [atom() | {atom(), any()}].
+-type options() :: [atom() | {atom(), any()}].
 
 %% =====================================================================
 
@@ -63,19 +71,17 @@ dir__defaults() ->
 %% @spec dir() -> ok
 %% @equiv dir("")
 
--spec dir() -> 'ok'.
+-spec dir() -> ok.
 
-dir() ->
-    dir("").
+dir() -> dir("").
 
 %% =====================================================================
 %% @spec dir(Dir) -> ok
 %% @equiv dir(Dir, [])
 
--spec dir(file:filename()) -> 'ok'.
+-spec dir(file:filename()) -> ok.
 
-dir(Dir) ->
-    dir(Dir, []).
+dir(Dir) -> dir(Dir, []).
 
 %% =====================================================================
 %% @spec dir(Directory::filename(), Options::[term()]) -> ok
@@ -125,23 +131,23 @@ dir(Dir) ->
 %% @see //stdlib/re
 %% @see file/2
 
--record(dir, {follow_links = false :: boolean(),
-	      recursive    = true  :: boolean(),
-	      options              :: options()}).
+-record(dir,
+        {follow_links = false :: boolean(),
+         recursive = true :: boolean(),
+         options :: options()}).
 
--spec dir(file:filename(), options()) -> 'ok'.
+-spec dir(file:filename(), options()) -> ok.
 
 dir(Dir, Opts) ->
     Opts1 = Opts ++ dir__defaults(),
-    Env = #dir{follow_links = proplists:get_bool(follow_links, Opts1),
+    Env = #dir{follow_links =
+                   proplists:get_bool(follow_links, Opts1),
                recursive = proplists:get_bool(recursive, Opts1),
                options = Opts1},
     Regexp = proplists:get_value(regexp, Opts1),
     case filename(Dir) of
-        "" ->
-            Dir1 = ".";
-        Dir1 ->
-            ok
+        "" -> Dir1 = ".";
+        Dir1 -> ok
     end,
     dir_1(Dir1, Regexp, Env).
 
@@ -157,30 +163,26 @@ dir_1(Dir, Regexp, Env) ->
     end.
 
 dir_2(Name, Regexp, Dir, Env) ->
-    File = if Dir =:= "" ->
-                   Name;
-              true ->
-                   filename:join(Dir, Name)
+    File = if Dir =:= "" -> Name;
+              true -> filename:join(Dir, Name)
            end,
     case file_type(File) of
-        {value, regular} ->
-            dir_4(File, Regexp, Env);
+        {value, regular} -> dir_4(File, Regexp, Env);
         {value, directory} when Env#dir.recursive =:= true ->
             case is_symlink(Name) of
-                false ->
-                    dir_3(Name, Dir, Regexp, Env);
+                false -> dir_3(Name, Dir, Regexp, Env);
                 true when Env#dir.follow_links =:= true ->
                     dir_3(Name, Dir, Regexp, Env);
-                _ ->
-                    ok
+                _ -> ok
             end;
-        _ ->
-            ok
+        _ -> ok
     end.
 
 dir_3(Name, Dir, Regexp, Env) ->
     Dir1 = filename:join(Dir, Name),
-    verbose("tidying directory `~ts'.", [Dir1], Env#dir.options),
+    verbose("tidying directory `~ts'.",
+            [Dir1],
+            Env#dir.options),
     dir_1(Dir1, Regexp, Env).
 
 dir_4(File, Regexp, Env) ->
@@ -189,33 +191,32 @@ dir_4(File, Regexp, Env) ->
             Opts = [{outfile, File}, {dir, ""} | Env#dir.options],
             case catch file(File, Opts) of
                 {'EXIT', Value} ->
-                    warn("error tidying `~ts'.~n~p", [File,Value], Opts);
-                _ ->
-                    ok
+                    warn("error tidying `~ts'.~n~p", [File, Value], Opts);
+                _ -> ok
             end;
-        nomatch ->
-            ok
+        nomatch -> ok
     end.
 
 file__defaults() ->
     [{backup_suffix, ?DEFAULT_BACKUP_SUFFIX},
-     backups, 
+     {backups, false},
      {dir, ?DEFAULT_DIR},
      {printer, default_printer()},
      {quiet, false},
      {verbose, false}].
 
 default_printer() ->
-    fun (Tree, Options) -> erl_prettypr:format(Tree, Options) end.
+    fun (Tree, Options) ->
+            erl_prettypr:format(Tree, Options)
+    end.
 
 %% =====================================================================
 %% @spec file(Name) -> ok
 %% @equiv file(Name, [])
 
--spec file(file:filename()) -> 'ok'.
+-spec file(file:filename()) -> ok.
 
-file(Name) ->
-    file(Name, []).
+file(Name) -> file(Name, []).
 
 %% =====================================================================
 %% @spec file(Name::filename(), Options::[term()]) -> ok
@@ -283,27 +284,24 @@ file(Name) ->
 %% @see erl_prettypr:format/2
 %% @see module/2
 
--spec file(file:filename(), options()) -> 'ok'.
+-spec file(file:filename(), options()) -> ok.
 
 file(Name, Opts) ->
     Parent = self(),
-    Child = spawn_link(fun () -> file_1(Parent, Name, Opts) end),
+    Child = spawn_link(fun () -> file_1(Parent, Name, Opts)
+                       end),
     receive
-        {Child, ok} ->
-            ok;
-        {Child, {error, Reason}} ->
-            exit(Reason)
+        {Child, ok} -> ok;
+        {Child, {error, Reason}} -> exit(Reason)
     end.
 
 file_1(Parent, Name, Opts) ->
     try file_2(Name, Opts) of
-	_ ->
-	    Parent ! {self(), ok}
+        _ -> Parent ! {self(), ok}
     catch
-	throw:syntax_error ->       % ignore syntax errors
-	    Parent ! {self(), ok};
-	error:Reason ->
-	    Parent ! {self(), {error, Reason}}
+        syntax_error ->       % ignore syntax errors
+            Parent ! {self(), ok};
+        error:Reason -> Parent ! {self(), {error, Reason}}
     end.
 
 file_2(Name, Opts) ->
@@ -313,21 +311,22 @@ file_2(Name, Opts) ->
     Forms1 = erl_recomment:recomment_forms(Forms, Comments),
     Tree = module(Forms1, [{file, Name} | Opts1]),
     case proplists:get_bool(test, Opts1) of
-        true ->
-            ok;
+        true -> ok;
         false ->
-			case proplists:get_bool(stdout, Opts1) of
-				true ->
-					print_module(Tree, Opts1),
-					ok;
-				false ->
-					write_module(Tree, Name, Opts1),
-					ok
-			end
-	end.
+            case proplists:get_bool(stdout, Opts1) of
+                true ->
+                    print_module(Tree, Opts1),
+                    ok;
+                false ->
+                    write_module(Tree, Name, Opts1),
+                    ok
+            end
+    end.
 
 read_module(Name, Opts) ->
-    verbose("reading module `~ts'.", [filename(Name)], Opts),
+    verbose("reading module `~ts'.",
+            [filename(Name)],
+            Opts),
     case epp_dodger:parse_file(Name, [no_fail]) of
         {ok, Forms} ->
             check_forms(Forms, Name),
@@ -342,16 +341,13 @@ check_forms(Fs, Name) ->
                   case erl_syntax:type(F) of
                       error_marker ->
                           S = case erl_syntax:error_marker_info(F) of
-                                  {_, M, D} ->
-                                      M:format_error(D);
-                                  _ ->
-                                      "unknown error"
+                                  {_, M, D} -> M:format_error(D);
+                                  _ -> "unknown error"
                               end,
-                          report_error({Name, erl_syntax:get_pos(F),
-                                        "\n  ~ts"}, [S]),
+                          report_error({Name, erl_syntax:get_pos(F), "\n  ~ts"},
+                                       [S]),
                           exit(error);
-                      _ ->
-                          ok
+                      _ -> ok
                   end
           end,
     lists:foreach(Fun, Fs).
@@ -360,86 +356,28 @@ check_forms(Fs, Name) ->
 %% then open the file, output the text and close the file
 %% safely. Returns the file name.
 
-write_module(Tree, Name, Opts) ->
-    Name1 = proplists:get_value(outfile, Opts, filename(Name)),
-    Dir = filename(proplists:get_value(dir, Opts, "")),
-    File = if Dir =:= "" ->
-                   Name1;
-              true ->
-                   case file_type(Dir) of
-                       {value, directory} ->
-                           ok;
-                       {value, _} ->
-                           report_error("`~ts' is not a directory.",
-                                        [filename(Dir)]),
-                           exit(error);
-                       none ->
-                           case file:make_dir(Dir) of
-                               ok ->
-                                   verbose("created directory `~ts'.",
-                                           [filename(Dir)], Opts),
-                                   ok;
-                               E ->
-                                   report_error("failed to create "
-                                                "directory `~ts'.",
-                                                [filename(Dir)]),
-                                   exit({make_dir, E})
-                           end
-                   end,
-                   filename(filename:join(Dir, Name1))
-           end,
-    Encoding = [{encoding,Enc} || Enc <- [epp:read_encoding(Name)],
-                                 Enc =/= none],
-    case proplists:get_bool(backups, Opts) of
-        true ->
-            backup_file(File, Opts);
-        false ->
-            ok
-    end,
-    Printer = proplists:get_value(printer, Opts),
-    FD = open_output_file(File, Encoding),
-    verbose("writing to file `~ts'.", [File], Opts),
-    V = (catch {ok, output(FD, Printer, Tree, Opts++Encoding)}),
-    ok = file:close(FD),
-    case V of
-        {ok, _} ->
-            File;
-        {'EXIT', R} ->
-            error_write_file(File),
-            exit(R);
-        R ->
-            error_write_file(File),
-            throw(R)
-    end.
+write_module ( Tree , Name , Opts ) -> Name1 = proplists : get_value ( outfile , Opts , filename ( Name ) ) , Dir = filename ( proplists : get_value ( dir , Opts , "" ) ) , File = if Dir =:= "" -> Name1 ; true -> case file_type ( Dir ) of { value , directory } -> ok ; { value , _ } -> report_error ( "`~ts' is not a directory." , [ filename ( Dir ) ] ) , exit ( error ) ; none -> case file : make_dir ( Dir ) of ok -> verbose ( "created directory `~ts'." , [ filename ( Dir ) ] , Opts ) , ok ; E -> report_error ( "failed to create directory `~ts'." , [ filename ( Dir ) ] ) , exit ( { make_dir , E } ) end end , filename ( filename : join ( Dir , Name1 ) ) end , Encoding = [ { encoding , Enc } || Enc <- [ epp : read_encoding ( Name ) ] , Enc =/= none ] , case proplists : get_bool ( backups , Opts ) of io : format ( "backups is true\n" ) ; true -> backup_file ( File , Opts ) ; false -> ok end , Printer = proplists : get_value ( printer , Opts ) , FD = open_output_file ( File , Encoding ) , verbose ( "writing to file `~ts'." , [ File ] , Opts ) , V = catch { ok , output ( FD , Printer , Tree , Opts ++ Encoding ) } , ok = file : close ( FD ) , case V of { ok , _ } -> File ; { 'EXIT' , R } -> error_write_file ( File ) , exit ( R ) ; R -> error_write_file ( File ) , throw ( R ) end .
+
 
 print_module(Tree, Opts) ->
-	Printer = proplists:get_value(printer, Opts),
-	io:format(Printer(Tree, Opts)).
-
-output(FD, Printer, Tree, Opts) ->
-    io:put_chars(FD, Printer(Tree, Opts)),
-    io:nl(FD).
+    Printer = proplists:get_value(printer, Opts),
+    io:format(Printer(Tree, Opts)).
 
 %% file_type(file:filename()) -> {value, Type} | none
 
-file_type(Name) ->
-    file_type(Name, false).
+file_type(Name) -> file_type(Name, false).
 
 is_symlink(Name) ->
     file_type(Name, true) =:= {value, symlink}.
 
 file_type(Name, Links) ->
     V = case Links of
-            true ->
-                catch file:read_link_info(Name);
-            false ->
-                catch file:read_file_info(Name)
+            true -> catch file:read_link_info(Name);
+            false -> catch file:read_file_info(Name)
         end,
     case V of
-        {ok, Env} ->
-            {value, Env#file_info.type};
-        {error, enoent} ->
-            none;
+        {ok, Env} -> {value, Env#file_info.type};
+        {error, enoent} -> none;
         {error, R} ->
             error_read_file(Name),
             exit({error, R});
@@ -449,65 +387,21 @@ file_type(Name, Links) ->
         R ->
             error_read_file(Name),
             throw(R)
-    end.
-
-open_output_file(FName, Options) ->
-    case catch file:open(FName, [write]++Options) of
-        {ok, FD} ->
-            FD;
-        {error, R} ->
-            error_open_output(FName),
-            exit({error, R});
-        {'EXIT', R} ->
-            error_open_output(FName),
-            exit(R);
-        R ->
-            error_open_output(FName),
-            exit(R)
     end.
 
 %% If the file exists, rename it by appending the given suffix to the
 %% file name.
 
-backup_file(Name, Opts) ->
-    case file_type(Name) of
-        {value, regular} ->
-            backup_file_1(Name, Opts);
-        {value, _} ->
-            error_backup_file(Name),
-            exit(error);
-        none ->
-            ok
-    end.
-
 %% The file should exist and be a regular file here.
-
-backup_file_1(Name, Opts) ->
-    Suffix = proplists:get_value(backup_suffix, Opts, ""),
-    Dest = filename:join(filename:dirname(Name),
-                         filename:basename(Name) ++ Suffix),
-    case catch file:rename(Name, Dest) of
-        ok ->
-            verbose("made backup of file `~ts'.", [Name], Opts);
-        {error, R} ->
-            error_backup_file(Name),
-            exit({error, R});
-        {'EXIT', R} ->
-            error_backup_file(Name),
-            exit(R);
-        R ->
-            error_backup_file(Name),
-            throw(R)
-    end.
 
 %% =====================================================================
 %% @spec module(Forms) -> syntaxTree()
 %% @equiv module(Forms, [])
 
--spec module(erl_syntax:forms()) -> erl_syntax:syntaxTree().
+-spec
+     module(erl_syntax:forms()) -> erl_syntax:syntaxTree().
 
-module(Forms) ->
-    module(Forms, []).
+module(Forms) -> module(Forms, []).
 
 %% =====================================================================
 %% @spec module(Forms, Options::[term()]) -> syntaxTree()
@@ -632,13 +526,14 @@ module(Forms) ->
 %%
 %% </dl>
 
--spec module(erl_syntax:forms(), [term()]) -> erl_syntax:syntaxTree().
+-spec module(erl_syntax:forms(),
+             [term()]) -> erl_syntax:syntaxTree().
 
 module(Forms, Opts) when is_list(Forms) ->
     module(erl_syntax:form_list(Forms), Opts);
 module(Forms, Opts) ->
-    Opts1 = proplists:expand(module__expansions(), Opts)
-	    ++ module__defaults(),
+    Opts1 = proplists:expand(module__expansions(), Opts) ++
+                module__defaults(),
     File = proplists:get_value(file, Opts1, ""),
     Forms1 = erl_syntax:flatten_form_list(Forms),
     module_1(Forms1, File, Opts1).
@@ -654,12 +549,13 @@ module__defaults() ->
      {verbose, false}].
 
 module__expansions() ->
-    [{idem, [{auto_export_vars, false},
-	     {auto_list_comp, false},
-	     {keep_unused, true},
-	     {new_guard_tests, false},
-	     {no_imports, false},
-	     {old_guard_tests, false}]}].
+    [{idem,
+      [{auto_export_vars, false},
+       {auto_list_comp, false},
+       {keep_unused, true},
+       {new_guard_tests, false},
+       {no_imports, false},
+       {old_guard_tests, false}]}].
 
 module_1(Forms, File, Opts) ->
     Info = analyze_forms(Forms, File),
@@ -673,8 +569,11 @@ module_1(Forms, File, Opts) ->
     Exports1 = check_export_all(Attrs, Names, Exports),
     Roots = ordsets:union(ordsets:from_list(Exports1),
                           hidden_uses(Fs, Imports)),
-    {Names1, Used, Imported, Defs1} = visit_used(Names, Defs, Roots,
-                                                 Imports, Module,
+    {Names1, Used, Imported, Defs1} = visit_used(Names,
+                                                 Defs,
+                                                 Roots,
+                                                 Imports,
+                                                 Module,
                                                  Opts1),
     Fs1 = update_forms(Fs, Defs1, Imported, Opts1),
     Fs2 = filter_forms(Fs1, Names1, Used, Opts1),
@@ -682,107 +581,101 @@ module_1(Forms, File, Opts) ->
 
 analyze_forms(Forms, File) ->
     case catch {ok, erl_syntax_lib:analyze_forms(Forms)} of
-        {ok, L1} ->
-            L1;
+        {ok, L1} -> L1;
         syntax_error ->
             report_error({File, 0, "syntax error."}),
-	    throw(syntax_error);
-        {'EXIT', R} ->
-            exit(R);
-        R ->
-            throw(R)
+            throw(syntax_error);
+        {'EXIT', R} -> exit(R);
+        R -> throw(R)
     end.
 
--spec get_module_name([erl_syntax_lib:info_pair()], string()) -> atom().
+-spec get_module_name([erl_syntax_lib:info_pair()],
+                      string()) -> atom().
 
 get_module_name(List, File) ->
     case lists:keyfind(module, 1, List) of
-        {module, M} ->
-            M;
+        {module, M} -> M;
         _ ->
-            report_error({File, 0,
+            report_error({File,
+                          0,
                           "cannot determine module name."}),
             exit(error)
     end.
 
 get_module_attributes(List) ->
     case lists:keyfind(attributes, 1, List) of
-        {attributes, As} ->
-            As;
-        _ ->
-            []
+        {attributes, As} -> As;
+        _ -> []
     end.
 
--spec get_module_exports([erl_syntax_lib:info_pair()]) -> [{atom(), arity()}].
+-spec
+     get_module_exports([erl_syntax_lib:info_pair()]) -> [{atom(),
+                                                           arity()}].
 
 get_module_exports(List) ->
     case lists:keyfind(exports, 1, List) of
-        {exports, Es} ->
-            Es;
-        _ ->
-            []
+        {exports, Es} -> Es;
+        _ -> []
     end.
 
--spec get_module_imports([erl_syntax_lib:info_pair()]) -> [{atom(), atom()}].
+-spec
+     get_module_imports([erl_syntax_lib:info_pair()]) -> [{atom(),
+                                                           atom()}].
 
 get_module_imports(List) ->
     case lists:keyfind(imports, 1, List) of
-        {imports, Is} ->
-            flatten_imports(Is);
-        _ ->
-            []
+        {imports, Is} -> flatten_imports(Is);
+        _ -> []
     end.
 
 compile_attrs(As) ->
-    lists:append([if is_list(T) -> T; true -> [T] end
+    lists:append([if is_list(T) -> T;
+                     true -> [T]
+                  end
                   || {compile, T} <- As]).
 
--spec flatten_imports([{atom(), [atom()]}]) -> [{atom(), atom()}].
+-spec flatten_imports([{atom(), [atom()]}]) -> [{atom(),
+                                                 atom()}].
 
 flatten_imports(Is) ->
     [{F, M} || {M, Fs} <- Is, F <- Fs].
 
 check_imports(Is, Opts, File) ->
     case check_imports_1(lists:sort(Is)) of
-        true ->
-            Opts;
+        true -> Opts;
         false ->
             case proplists:get_bool(no_imports, Opts) of
                 true ->
-                    warn({File, 0,
-			  "conflicting import declarations - "
-			  "will not expand imports."},
-			 [], Opts),
+                    warn({File,
+                          0,
+                          "conflicting import declarations - will "
+                          "not expand imports."},
+                         [],
+                         Opts),
                     %% prevent expansion of imports
                     [{no_imports, false} | Opts];
-                false ->
-                    Opts
+                false -> Opts
             end
     end.
 
 -spec check_imports_1([{atom(), atom()}]) -> boolean().
 
-check_imports_1([{F, M1}, {F, M2} | _Is]) when M1 =/= M2 ->
+check_imports_1([{F, M1}, {F, M2} | _Is])
+    when M1 =/= M2 ->
     false;
-check_imports_1([_ | Is]) ->
-    check_imports_1(Is);
-check_imports_1([]) ->
-    true.
+check_imports_1([_ | Is]) -> check_imports_1(Is);
+check_imports_1([]) -> true.
 
 check_export_all(Attrs, Names, Exports) ->
     case lists:member(export_all, compile_attrs(Attrs)) of
-        true ->
-            Exports ++ sets:to_list(Names);
-        false ->
-            Exports
+        true -> Exports ++ sets:to_list(Names);
+        false -> Exports
     end.
 
 filter_forms(Fs, Names, Used, Opts) ->
     Keep = case proplists:get_bool(keep_unused, Opts) of
-               true ->
-                   Names;
-               false ->
-                   Used
+               true -> Names;
+               false -> Used
            end,
     [F || F <- Fs, keep_form(F, Keep, Opts)].
 
@@ -794,93 +687,86 @@ keep_form(Form, Used, Opts) ->
                 false ->
                     {F, A} = N,
                     File = proplists:get_value(file, Opts, ""),
-                    report({File, erl_syntax:get_pos(Form),
+                    report({File,
+                            erl_syntax:get_pos(Form),
                             "removing unused function `~w/~w'."},
-                           [F, A], Opts),
+                           [F, A],
+                           Opts),
                     false;
-                true ->
-                    true
+                true -> true
             end;
         attribute ->
             case erl_syntax_lib:analyze_attribute(Form) of
-                {file, _} ->
-                    false;
-                _ ->
-                    true
+                {file, _} -> false;
+                _ -> true
             end;
-        error_marker ->
-            false;
-        warning_marker ->
-            false;
-        eof_marker ->
-            false;
-        _ ->
-            true
+        error_marker -> false;
+        warning_marker -> false;
+        eof_marker -> false;
+        _ -> true
     end.
 
 collect_functions(Forms) ->
-    lists:foldl(
-      fun (F, {Names, Defs}) ->
-              case erl_syntax:type(F) of
-                  function ->
-                      N = erl_syntax_lib:analyze_function(F),
-                      {sets:add_element(N, Names),
-                       dict:store(N, {F, []}, Defs)};
-                  _ ->
-                      {Names, Defs}
-              end
-      end,
-      {sets:new(), dict:new()},
-      Forms).
+    lists:foldl(fun (F, {Names, Defs}) ->
+                        case erl_syntax:type(F) of
+                            function ->
+                                N = erl_syntax_lib:analyze_function(F),
+                                {sets:add_element(N, Names),
+                                 dict:store(N, {F, []}, Defs)};
+                            _ -> {Names, Defs}
+                        end
+                end,
+                {sets:new(), dict:new()},
+                Forms).
 
 update_forms([F | Fs], Defs, Imports, Opts) ->
     case erl_syntax:type(F) of
         function ->
             N = erl_syntax_lib:analyze_function(F),
             {F1, Fs1} = dict:fetch(N, Defs),
-            [F1 | lists:reverse(Fs1)] ++ update_forms(Fs, Defs, Imports,
-                                                      Opts);
+            [F1 | lists:reverse(Fs1)] ++
+                update_forms(Fs, Defs, Imports, Opts);
         attribute ->
-            [update_attribute(F, Imports, Opts)
-             | update_forms(Fs, Defs, Imports, Opts)];
-        _ ->
-            [F | update_forms(Fs, Defs, Imports, Opts)]
+            [update_attribute(F, Imports, Opts) | update_forms(Fs,
+                                                               Defs,
+                                                               Imports,
+                                                               Opts)];
+        _ -> [F | update_forms(Fs, Defs, Imports, Opts)]
     end;
-update_forms([], _, _, _) ->
-    [].
+update_forms([], _, _, _) -> [].
 
 update_attribute(F, Imports, Opts) ->
     case erl_syntax_lib:analyze_attribute(F) of
         {import, {M, Ns}} ->
-            Ns1 = ordsets:from_list([N || N <- Ns,
-                                          sets:is_element(N, Imports)]),
+            Ns1 = ordsets:from_list([N
+                                     || N <- Ns, sets:is_element(N, Imports)]),
             case ordsets:subtract(ordsets:from_list(Ns), Ns1) of
-                [] ->
-                    ok;
+                [] -> ok;
                 Names ->
                     File = proplists:get_value(file, Opts, ""),
-                    report({File, erl_syntax:get_pos(F),
-			    "removing unused imports:~s"},
-			   [[io_lib:fwrite("\n\t`~w:~w/~w'", [M, N, A])
-			     || {N, A} <- Names]], Opts)
+                    report({File,
+                            erl_syntax:get_pos(F),
+                            "removing unused imports:~s"},
+                           [[io_lib:fwrite("\n\t`~w:~w/~w'", [M, N, A])
+                             || {N, A} <- Names]],
+                           Opts)
             end,
             Is = [make_fname(N) || N <- Ns1],
             if Is =:= [] ->
-                    %% This will be filtered out later.
-                    erl_syntax:warning_marker(deleted);
+                   %% This will be filtered out later.
+                   erl_syntax:warning_marker(deleted);
                true ->
-                    F1 = erl_syntax:attribute(erl_syntax:atom(import),
-                                              [erl_syntax:atom(M),
-                                               erl_syntax:list(Is)]),
-                    rewrite(F, F1)
+                   F1 = erl_syntax:attribute(erl_syntax:atom(import),
+                                             [erl_syntax:atom(M),
+                                              erl_syntax:list(Is)]),
+                   rewrite(F, F1)
             end;
         {export, Ns} ->
             Es = [make_fname(N) || N <- ordsets:from_list(Ns)],
             F1 = erl_syntax:attribute(erl_syntax:atom(export),
                                       [erl_syntax:list(Es)]),
             rewrite(F, F1);
-        _ ->
-            F
+        _ -> F
     end.
 
 make_fname({F, A}) ->
@@ -890,14 +776,14 @@ make_fname({F, A}) ->
 hidden_uses(Fs, Imports) ->
     Used = lists:foldl(fun (F, S) ->
                                case erl_syntax:type(F) of
-                                   attribute ->
-                                       hidden_uses_1(F, S);
-                                   _ ->
-                                       S
+                                   attribute -> hidden_uses_1(F, S);
+                                   _ -> S
                                end
                        end,
-                       [], Fs),
-    ordsets:subtract(Used, ordsets:from_list([F || {F, _M} <- Imports])).
+                       [],
+                       Fs),
+    ordsets:subtract(Used,
+                     ordsets:from_list([F || {F, _M} <- Imports])).
 
 hidden_uses_1(Tree, Used) ->
     erl_syntax_lib:fold(fun hidden_uses_2/2, Used, Tree).
@@ -911,92 +797,90 @@ hidden_uses_2(Tree, Used) ->
                     As = erl_syntax:application_arguments(Tree),
                     N = {erl_syntax:atom_value(F), length(As)},
                     case is_auto_imported(N) of
-                        true ->
-                            Used;
-                        false ->
-                            ordsets:add_element(N, Used)
+                        true -> Used;
+                        false -> ordsets:add_element(N, Used)
                     end;
-                _ ->
-                    Used
+                _ -> Used
             end;
         implicit_fun ->
             F = erl_syntax:implicit_fun_name(Tree),
-            case catch {ok, erl_syntax_lib:analyze_function_name(F)} of
+            case catch {ok, erl_syntax_lib:analyze_function_name(F)}
+                of
                 {ok, {Name, Arity} = N}
-                when is_atom(Name), is_integer(Arity) ->
+                    when is_atom(Name), is_integer(Arity) ->
                     ordsets:add_element(N, Used);
-                _ ->
-                    Used
+                _ -> Used
             end;
-        _ ->
-            Used
+        _ -> Used
     end.
 
--type fa()      :: {atom(), arity()}.
--type context() :: 'guard_expr' | 'guard_test' | 'normal'.
+-type fa() :: {atom(), arity()}.
 
--record(env, {file		       :: file:filename(),
-              module                   :: atom(),
-              current                  :: fa() | 'undefined',
-              imports = dict:new()     :: dict:dict(atom(), atom()),
-              context = normal	       :: context(),
-              verbosity = 1	       :: 0 | 1 | 2,
-              quiet = false            :: boolean(),
-              no_imports = false       :: boolean(),
-              spawn_funs = false       :: boolean(),
-              auto_list_comp = true    :: boolean(),
-              auto_export_vars = false :: boolean(),
-              new_guard_tests = true   :: boolean(),
-	      old_guard_tests = false  :: boolean()}).
+-type context() :: guard_expr | guard_test | normal.
 
--record(st, {varc              :: non_neg_integer() | 'undefined',
-	     used = sets:new() :: sets:set({atom(), arity()}),
-	     imported          :: sets:set({atom(), arity()}),
-	     vars              :: sets:set(atom()) | 'undefined',
-	     functions         :: sets:set({atom(), arity()}),
-	     new_forms = []    :: [erl_syntax:syntaxTree()],
-	     rename            :: dict:dict(mfa(), {atom(), atom()})}).
+-record(env,
+        {file :: file:filename(),
+         module :: atom(),
+         current :: fa() | undefined,
+         imports = dict:new() :: dict:dict(atom(), atom()),
+         context = normal :: context(),
+         verbosity = 1 :: 0 | 1 | 2,
+         quiet = false :: boolean(),
+         no_imports = false :: boolean(),
+         spawn_funs = false :: boolean(),
+         auto_list_comp = true :: boolean(),
+         auto_export_vars = false :: boolean(),
+         new_guard_tests = true :: boolean(),
+         old_guard_tests = false :: boolean()}).
+
+-record(st,
+        {varc :: non_neg_integer() | undefined,
+         used = sets:new() :: sets:set({atom(), arity()}),
+         imported :: sets:set({atom(), arity()}),
+         vars :: sets:set(atom()) | undefined,
+         functions :: sets:set({atom(), arity()}),
+         new_forms = [] :: [erl_syntax:syntaxTree()],
+         rename :: dict:dict(mfa(), {atom(), atom()})}).
 
 visit_used(Names, Defs, Roots, Imports, Module, Opts) ->
     File = proplists:get_value(file, Opts, ""),
     NoImports = proplists:get_bool(no_imports, Opts),
     Rename = proplists:append_values(rename, Opts),
-    loop(Roots, sets:new(), Defs,
-         #env{file = File,
-              module = Module,
+    loop(Roots,
+         sets:new(),
+         Defs,
+         #env{file = File, module = Module,
               imports = dict:from_list(Imports),
-              verbosity = verbosity(Opts),
-              no_imports = NoImports,
+              verbosity = verbosity(Opts), no_imports = NoImports,
               spawn_funs = proplists:get_bool(spawn_funs, Opts),
-              auto_list_comp = proplists:get_bool(auto_list_comp, Opts),
-              auto_export_vars = proplists:get_bool(auto_export_vars,
-						    Opts),
-              new_guard_tests = proplists:get_bool(new_guard_tests,
-						   Opts),
-              old_guard_tests = proplists:get_bool(old_guard_tests,
-						   Opts)},
-         #st{used = sets:from_list(Roots),
-             imported = sets:new(),
+              auto_list_comp =
+                  proplists:get_bool(auto_list_comp, Opts),
+              auto_export_vars =
+                  proplists:get_bool(auto_export_vars, Opts),
+              new_guard_tests =
+                  proplists:get_bool(new_guard_tests, Opts),
+              old_guard_tests =
+                  proplists:get_bool(old_guard_tests, Opts)},
+         #st{used = sets:from_list(Roots), imported = sets:new(),
              functions = Names,
-             rename = dict:from_list([X || {F1, F2} = X <- Rename,
-                                           is_remote_name(F1),
-                                           is_atom_pair(F2)])}).
+             rename =
+                 dict:from_list([X
+                                 || {F1, F2} = X <- Rename, is_remote_name(F1),
+                                    is_atom_pair(F2)])}).
 
 loop([F | Work], Seen0, Defs0, Env, St0) ->
     case sets:is_element(F, Seen0) of
-        true ->
-            loop(Work, Seen0, Defs0, Env, St0);
+        true -> loop(Work, Seen0, Defs0, Env, St0);
         false ->
             Seen1 = sets:add_element(F, Seen0),
             case dict:find(F, Defs0) of
                 {ok, {Form, Fs}} ->
                     Vars = erl_syntax_lib:variables(Form),
                     Form1 = erl_syntax_lib:annotate_bindings(Form, []),
-                    {Form2, St1} = visit(Form1, Env#env{current = F},
-                                         St0#st{varc = 1,
-                                                used = sets:new(),
-                                                vars = Vars,
-                                                new_forms = []}),
+                    {Form2, St1} = visit(Form1,
+                                         Env#env{current = F},
+                                         St0#st{varc = 1, used = sets:new(),
+                                                vars = Vars, new_forms = []}),
                     Fs1 = St1#st.new_forms ++ Fs,
                     Defs1 = dict:store(F, {Form2, Fs1}, Defs0),
                     Used = St1#st.used,
@@ -1013,22 +897,14 @@ loop([], _, Defs, _, St) ->
 
 visit(Tree, Env, St0) ->
     case erl_syntax:type(Tree) of
-        application ->
-            visit_application(Tree, Env, St0);
-        infix_expr ->
-            visit_infix_expr(Tree, Env, St0);
-        prefix_expr ->
-            visit_prefix_expr(Tree, Env, St0);
-        implicit_fun ->
-            visit_implicit_fun(Tree, Env, St0);
-        clause ->
-            visit_clause(Tree, Env, St0);
-        list_comp ->
-            visit_list_comp(Tree, Env, St0);
-        match_expr ->
-            visit_match_expr(Tree, Env, St0);
-        _ ->
-            visit_other(Tree, Env, St0)
+        application -> visit_application(Tree, Env, St0);
+        infix_expr -> visit_infix_expr(Tree, Env, St0);
+        prefix_expr -> visit_prefix_expr(Tree, Env, St0);
+        implicit_fun -> visit_implicit_fun(Tree, Env, St0);
+        clause -> visit_clause(Tree, Env, St0);
+        list_comp -> visit_list_comp(Tree, Env, St0);
+        match_expr -> visit_match_expr(Tree, Env, St0);
+        _ -> visit_other(Tree, Env, St0)
     end.
 
 visit_other(Tree, Env, St) ->
@@ -1036,17 +912,20 @@ visit_other(Tree, Env, St) ->
     erl_syntax_lib:mapfold_subtrees(F, St, Tree).
 
 visit_list(Ts, Env, St0) ->
-    lists:mapfoldl(fun (T, S) -> visit(T, Env, S) end, St0, Ts).
+    lists:mapfoldl(fun (T, S) -> visit(T, Env, S) end,
+                   St0,
+                   Ts).
 
 visit_implicit_fun(Tree, _Env, St0) ->
     F = erl_syntax:implicit_fun_name(Tree),
-    case catch {ok, erl_syntax_lib:analyze_function_name(F)} of
+    case catch {ok, erl_syntax_lib:analyze_function_name(F)}
+        of
         {ok, {Name, Arity} = N}
-        when is_atom(Name), is_integer(Arity) ->
+            when is_atom(Name), is_integer(Arity) ->
             Used = sets:add_element(N, St0#st.used),
             {Tree, St0#st{used = Used}};
         _ ->
-	    %% symbolic funs do not count as uses of a function
+            %% symbolic funs do not count as uses of a function
             {Tree, St0}
     end.
 
@@ -1054,23 +933,29 @@ visit_clause(Tree, Env, St0) ->
     %% We do not visit the patterns (for now, anyway).
     Ps = erl_syntax:clause_patterns(Tree),
     {G, St1} = case erl_syntax:clause_guard(Tree) of
-                   none ->
-                       {none, St0};
-                   G0 ->
-                       visit(G0, Env#env{context = guard_test}, St0)
+                   none -> {none, St0};
+                   G0 -> visit(G0, Env#env{context = guard_test}, St0)
                end,
-    {B, St2} = visit_list(erl_syntax:clause_body(Tree), Env, St1),
+    {B, St2} = visit_list(erl_syntax:clause_body(Tree),
+                          Env,
+                          St1),
     {rewrite(Tree, erl_syntax:clause(Ps, G, B)), St2}.
 
-visit_infix_expr(Tree, #env{context = guard_test}, St0) ->
+visit_infix_expr(Tree, #env{context = guard_test},
+                 St0) ->
     %% Detect transition from guard test to guard expression.
-    visit_other(Tree, #env{context = guard_expr, file = ""}, St0);
+    visit_other(Tree,
+                #env{context = guard_expr, file = ""},
+                St0);
 visit_infix_expr(Tree, Env, St0) ->
     visit_other(Tree, Env, St0).
 
-visit_prefix_expr(Tree, #env{context = guard_test}, St0) ->
+visit_prefix_expr(Tree, #env{context = guard_test},
+                  St0) ->
     %% Detect transition from guard test to guard expression.
-    visit_other(Tree, #env{context = guard_expr, file = ""}, St0);
+    visit_other(Tree,
+                #env{context = guard_expr, file = ""},
+                St0);
 visit_prefix_expr(Tree, Env, St0) ->
     visit_other(Tree, Env, St0).
 
@@ -1078,129 +963,142 @@ visit_application(Tree, Env, St0) ->
     Env1 = case Env of
                #env{context = guard_test} ->
                    Env#env{context = guard_expr};
-               _ ->
-                   Env
+               _ -> Env
            end,
-    {F, St1} = visit(erl_syntax:application_operator(Tree), Env1, St0),
-    {As, St2} = visit_list(erl_syntax:application_arguments(Tree), Env1,
-                           St1),
+    {F, St1} = visit(erl_syntax:application_operator(Tree),
+                     Env1,
+                     St0),
+    {As, St2} =
+        visit_list(erl_syntax:application_arguments(Tree),
+                   Env1,
+                   St1),
     case erl_syntax:type(F) of
-        atom ->
-            visit_atom_application(F, As, Tree, Env, St2);
+        atom -> visit_atom_application(F, As, Tree, Env, St2);
         implicit_fun ->
             visit_named_fun_application(F, As, Tree, Env, St2);
         fun_expr ->
             visit_lambda_application(F, As, Tree, Env, St2);
-        _ ->
-            visit_nonlocal_application(F, As, Tree, Env, St2)
+        _ -> visit_nonlocal_application(F, As, Tree, Env, St2)
     end.
 
 visit_application_final(F, As, Tree, St0) ->
     {rewrite(Tree, erl_syntax:application(F, As)), St0}.
 
 revisit_application(F, As, Tree, Env, St0) ->
-    visit(rewrite(Tree, erl_syntax:application(F, As)), Env, St0).
+    visit(rewrite(Tree, erl_syntax:application(F, As)),
+          Env,
+          St0).
 
-visit_atom_application(F, As, Tree, #env{context = guard_test} = Env,
-                       St0) ->
+visit_atom_application(F, As, Tree,
+                       #env{context = guard_test} = Env, St0) ->
     N = erl_syntax:atom_value(F),
     A = length(As),
     N1 = case Env#env.old_guard_tests of
-             true ->
-                 reverse_guard_test(N, A);
+             true -> reverse_guard_test(N, A);
              false ->
-		 case Env#env.new_guard_tests of
-		     true ->
-			 rewrite_guard_test(N, A);
-		     false ->
-			 N
-		 end
-	 end,
+                 case Env#env.new_guard_tests of
+                     true -> rewrite_guard_test(N, A);
+                     false -> N
+                 end
+         end,
     if N1 =/= N ->
-            report({Env#env.file, erl_syntax:get_pos(F),
-		    "changing guard test `~w' to `~w'."},
-		   [N, N1], Env#env.verbosity);
-       true ->
-            ok
+           report({Env#env.file,
+                   erl_syntax:get_pos(F),
+                   "changing guard test `~w' to `~w'."},
+                  [N, N1],
+                  Env#env.verbosity);
+       true -> ok
     end,
     %% No need to revisit here.
     F1 = rewrite(F, erl_syntax:atom(N1)),
     visit_application_final(F1, As, Tree, St0);
-visit_atom_application(F, As, Tree, #env{context = guard_expr}, St0) ->
+visit_atom_application(F, As, Tree,
+                       #env{context = guard_expr}, St0) ->
     %% Atom applications in guard expressions are never local calls.
     visit_application_final(F, As, Tree, St0);
 visit_atom_application(F, As, Tree, Env, St0) ->
     N = {erl_syntax:atom_value(F), length(As)},
     case is_auto_imported(N) of
-        true ->
-            visit_bif_call(N, F, As, Tree, Env, St0);
+        true -> visit_bif_call(N, F, As, Tree, Env, St0);
         false ->
             case is_imported(N, Env) of
                 true ->
                     visit_import_application(N, F, As, Tree, Env, St0);
                 false ->
                     Used = sets:add_element(N, St0#st.used),
-                    visit_application_final(F, As, Tree,
+                    visit_application_final(F,
+                                            As,
+                                            Tree,
                                             St0#st{used = Used})
             end
     end.
 
-visit_import_application({N, A} = Name, F, As, Tree, Env, St0) ->
+visit_import_application({N, A} = Name, F, As, Tree,
+                         Env, St0) ->
     M = dict:fetch(Name, Env#env.imports),
     Expand = case Env#env.no_imports of
-                 true ->
-                     true;
-                 false ->
-                     auto_expand_import({M, N, A}, St0)
+                 true -> true;
+                 false -> auto_expand_import({M, N, A}, St0)
              end,
     case Expand of
         true ->
-            report({Env#env.file, erl_syntax:get_pos(F),
-		    "expanding call to imported function `~w:~w/~w'."},
-		   [M, N, A], Env#env.verbosity),
+            report({Env#env.file,
+                    erl_syntax:get_pos(F),
+                    "expanding call to imported function "
+                    "`~w:~w/~w'."},
+                   [M, N, A],
+                   Env#env.verbosity),
             F1 = erl_syntax:module_qualifier(erl_syntax:atom(M),
                                              erl_syntax:atom(N)),
             revisit_application(rewrite(F, F1), As, Tree, Env, St0);
         false ->
             Is = sets:add_element(Name, St0#st.imported),
-            visit_application_final(F, As, Tree, St0#st{imported = Is})
+            visit_application_final(F,
+                                    As,
+                                    Tree,
+                                    St0#st{imported = Is})
     end.
 
-visit_bif_call({apply, 2}, F, [E, Args] = As, Tree, Env, St0) ->
+visit_bif_call({apply, 2}, F, [E, Args] = As, Tree, Env,
+               St0) ->
     case erl_syntax:is_proper_list(Args) of
         true ->
-            report({Env#env.file, erl_syntax:get_pos(F),
-		    "changing use of `apply/2' "
-		    "to direct function call."},
-		   [], Env#env.verbosity),
+            report({Env#env.file,
+                    erl_syntax:get_pos(F),
+                    "changing use of `apply/2' to direct "
+                    "function call."},
+                   [],
+                   Env#env.verbosity),
             As1 = erl_syntax:list_elements(Args),
             revisit_application(E, As1, Tree, Env, St0);
-        false ->
-            visit_application_final(F, As, Tree, St0)
+        false -> visit_application_final(F, As, Tree, St0)
     end;
-visit_bif_call({apply, 3}, F, [M, N, Args] = As, Tree, Env, St0) ->
+visit_bif_call({apply, 3}, F, [M, N, Args] = As, Tree,
+               Env, St0) ->
     case erl_syntax:is_proper_list(Args) of
         true ->
-            report({Env#env.file, erl_syntax:get_pos(F),
-		    "changing use of `apply/3' "
-		    "to direct remote call."},
-		   [], Env#env.verbosity),
+            report({Env#env.file,
+                    erl_syntax:get_pos(F),
+                    "changing use of `apply/3' to direct "
+                    "remote call."},
+                   [],
+                   Env#env.verbosity),
             F1 = rewrite(F, erl_syntax:module_qualifier(M, N)),
             As1 = erl_syntax:list_elements(Args),
             visit_nonlocal_application(F1, As1, Tree, Env, St0);
-        false ->
-            visit_application_final(F, As, Tree, St0)
+        false -> visit_application_final(F, As, Tree, St0)
     end;
-visit_bif_call({spawn, 3} = N, F, [_, _, _] = As, Tree, Env, St0) ->
+visit_bif_call({spawn, 3} = N, F, [_, _, _] = As, Tree,
+               Env, St0) ->
     visit_spawn_call(N, F, [], As, Tree, Env, St0);
-visit_bif_call({spawn_link, 3} = N, F, [_, _, _] = As, Tree, Env,
-               St0) ->
+visit_bif_call({spawn_link, 3} = N, F, [_, _, _] = As,
+               Tree, Env, St0) ->
     visit_spawn_call(N, F, [], As, Tree, Env, St0);
-visit_bif_call({spawn, 4} = N, F, [A | [_, _, _] = As], Tree, Env,
-               St0) ->
+visit_bif_call({spawn, 4} = N, F, [A | [_, _, _] = As],
+               Tree, Env, St0) ->
     visit_spawn_call(N, F, [A], As, Tree, Env, St0);
-visit_bif_call({spawn_link, 4} = N, F, [A | [_, _, _] = As], Tree, Env,
-               St0) ->
+visit_bif_call({spawn_link, 4} = N, F,
+               [A | [_, _, _] = As], Tree, Env, St0) ->
     visit_spawn_call(N, F, [A], As, Tree, Env, St0);
 visit_bif_call(_, F, As, Tree, _Env, St0) ->
     visit_application_final(F, As, Tree, St0).
@@ -1209,15 +1107,16 @@ visit_spawn_call({N, A}, F, Ps, [A1, A2, A3] = As, Tree,
                  #env{spawn_funs = true} = Env, St0) ->
     case erl_syntax:is_proper_list(A3) of
         true ->
-            report({Env#env.file, erl_syntax:get_pos(F),
-		    "changing use of `~w/~w' to `~w/~w' with a fun."},
-		   [N, A, N, 1 + length(Ps)], Env#env.verbosity),
+            report({Env#env.file,
+                    erl_syntax:get_pos(F),
+                    "changing use of `~w/~w' to `~w/~w' with "
+                    "a fun."},
+                   [N, A, N, 1 + length(Ps)],
+                   Env#env.verbosity),
             F1 = case erl_syntax:is_atom(A1, Env#env.module) of
                      true ->
                          A2;    % calling self
-                     false ->
-                         clone(A1,
-                               erl_syntax:module_qualifier(A1, A2))
+                     false -> clone(A1, erl_syntax:module_qualifier(A1, A2))
                  end,
             %% Need to do some scoping tricks here to make sure the
             %% arguments are evaluated by the parent, not by the spawned
@@ -1233,49 +1132,63 @@ visit_spawn_call({N, A}, F, Ps, [A1, A2, A3] = As, Tree,
             E5 = erl_syntax_lib:annotate_bindings(E4, get_env(A1)),
             {E6, St2} = visit(E5, Env, St1),
             F2 = rewrite(F, erl_syntax:atom(N)),
-            visit_nonlocal_application(F2, Ps ++ [E6], Tree, Env, St2);
-        false ->
-            visit_application_final(F, Ps ++ As, Tree, St0)
+            visit_nonlocal_application(F2,
+                                       Ps ++ [E6],
+                                       Tree,
+                                       Env,
+                                       St2);
+        false -> visit_application_final(F, Ps ++ As, Tree, St0)
     end;
 visit_spawn_call(_, F, Ps, As, Tree, _Env, St0) ->
     visit_application_final(F, Ps ++ As, Tree, St0).
 
 visit_named_fun_application(F, As, Tree, Env, St0) ->
     Name = erl_syntax:implicit_fun_name(F),
-    case catch {ok, erl_syntax_lib:analyze_function_name(Name)} of
-        {ok, {A, N}} when is_atom(A), is_integer(N), N =:= length(As) ->
+    case catch {ok,
+                erl_syntax_lib:analyze_function_name(Name)}
+        of
+        {ok, {A, N}}
+            when is_atom(A), is_integer(N), N =:= length(As) ->
             case is_nonlocal({A, N}, Env) of
                 true ->
                     %% Making this a direct call would be an error.
                     visit_application_final(F, As, Tree, St0);
                 false ->
-                    report({Env#env.file, erl_syntax:get_pos(F),
-			    "changing application of implicit fun "
-			    "to direct local call."},
-			   [], Env#env.verbosity),
+                    report({Env#env.file,
+                            erl_syntax:get_pos(F),
+                            "changing application of implicit fun "
+                            "to direct local call."},
+                           [],
+                           Env#env.verbosity),
                     Used = sets:add_element({A, N}, St0#st.used),
                     F1 = rewrite(F, erl_syntax:atom(A)),
-                    revisit_application(F1, As, Tree, Env,
+                    revisit_application(F1,
+                                        As,
+                                        Tree,
+                                        Env,
                                         St0#st{used = Used})
             end;
-        _  ->
-            visit_application_final(F, As, Tree, St0)
+        _ -> visit_application_final(F, As, Tree, St0)
     end.
 
 visit_lambda_application(F, As, Tree, Env, St0) ->
     A = erl_syntax:fun_expr_arity(F),
     case A =:= length(As) of
         true ->
-            report({Env#env.file, erl_syntax:get_pos(F),
-		    "changing application of fun-expression "
-		    "to local function call."},
-		   [], Env#env.verbosity),
+            report({Env#env.file,
+                    erl_syntax:get_pos(F),
+                    "changing application of fun-expression "
+                    "to local function call."},
+                   [],
+                   Env#env.verbosity),
             {Base, _} = Env#env.current,
-            Free = [erl_syntax:variable(V) || V <- get_free_vars(F)],
+            Free = [erl_syntax:variable(V)
+                    || V <- get_free_vars(F)],
             N = length(Free),
             A1 = A + N,
             {Name, St1} = new_fname({Base, A1}, St0),
-            Cs = augment_clauses(erl_syntax:fun_expr_clauses(F), Free),
+            Cs = augment_clauses(erl_syntax:fun_expr_clauses(F),
+                                 Free),
             F1 = erl_syntax:atom(Name),
             New = rewrite(F, erl_syntax:function(F1, Cs)),
             Used = sets:add_element({Name, A1}, St1#st.used),
@@ -1283,18 +1196,20 @@ visit_lambda_application(F, As, Tree, Env, St0) ->
             St2 = St1#st{new_forms = Forms, used = Used},
             visit_application_final(F1, As ++ Free, Tree, St2);
         false ->
-            warn({Env#env.file, erl_syntax:get_pos(F),
-		  "arity mismatch in fun-expression application."},
-		 [], Env#env.verbosity),
+            warn({Env#env.file,
+                  erl_syntax:get_pos(F),
+                  "arity mismatch in fun-expression application."},
+                 [],
+                 Env#env.verbosity),
             visit_application_final(F, As, Tree, St0)
     end.
 
 augment_clauses(Cs, Vs) ->
     [begin
-	 Ps = erl_syntax:clause_patterns(C),
-	 G = erl_syntax:clause_guard(C),
-	 Es = erl_syntax:clause_body(C),
-	 rewrite(C, erl_syntax:clause(Ps ++ Vs, G, Es))
+         Ps = erl_syntax:clause_patterns(C),
+         G = erl_syntax:clause_guard(C),
+         Es = erl_syntax:clause_body(C),
+         rewrite(C, erl_syntax:clause(Ps ++ Vs, G, Es))
      end
      || C <- Cs].
 
@@ -1303,88 +1218,104 @@ visit_nonlocal_application(F, As, Tree, Env, St0) ->
         tuple ->
             case erl_syntax:tuple_elements(F) of
                 [X1, X2] ->
-                    report({Env#env.file, erl_syntax:get_pos(F),
-			    "changing application of 2-tuple "
-			    "to direct remote call."},
-			   [], Env#env.verbosity),
+                    report({Env#env.file,
+                            erl_syntax:get_pos(F),
+                            "changing application of 2-tuple to direct "
+                            "remote call."},
+                           [],
+                           Env#env.verbosity),
                     F1 = erl_syntax:module_qualifier(X1, X2),
-                    revisit_application(rewrite(F, F1), As, Tree, Env,
-                                        St0);
-                _ ->
-                    visit_application_final(F, As, Tree, St0)
+                    revisit_application(rewrite(F, F1), As, Tree, Env, St0);
+                _ -> visit_application_final(F, As, Tree, St0)
             end;
         module_qualifier ->
-            case catch {ok, erl_syntax_lib:analyze_function_name(F)} of
+            case catch {ok, erl_syntax_lib:analyze_function_name(F)}
+                of
                 {ok, {M, N}} when is_atom(M), is_atom(N) ->
-                    visit_remote_application({M, N, length(As)}, F, As,
-                                             Tree, Env, St0);
-                _ ->
-                    visit_application_final(F, As, Tree, St0)
+                    visit_remote_application({M, N, length(As)},
+                                             F,
+                                             As,
+                                             Tree,
+                                             Env,
+                                             St0);
+                _ -> visit_application_final(F, As, Tree, St0)
             end;
-        _ ->
-            visit_application_final(F, As, Tree, St0)
+        _ -> visit_application_final(F, As, Tree, St0)
     end.
 
 %% --- lists:append/2 and lists:subtract/2 ---
-visit_remote_application({lists, append, 2}, F, [A1, A2], Tree, Env,
-                         St0) ->
-    report({Env#env.file, erl_syntax:get_pos(F),
-	    "replacing call to `lists:append/2' "
-	    "with the `++' operator."},
-	   [], Env#env.verbosity),
-    Tree1 = erl_syntax:infix_expr(A1, erl_syntax:operator('++'), A2),
+visit_remote_application({lists, append, 2}, F,
+                         [A1, A2], Tree, Env, St0) ->
+    report({Env#env.file,
+            erl_syntax:get_pos(F),
+            "replacing call to `lists:append/2' with "
+            "the `++' operator."},
+           [],
+           Env#env.verbosity),
+    Tree1 = erl_syntax:infix_expr(A1,
+                                  erl_syntax:operator('++'),
+                                  A2),
     visit(rewrite(Tree, Tree1), Env, St0);
-visit_remote_application({lists, subtract, 2}, F, [A1, A2], Tree, Env,
-                         St0) ->
-    report({Env#env.file, erl_syntax:get_pos(F),
-	    "replacing call to `lists:subtract/2' "
-	    "with the `--' operator."},
-	   [], Env#env.verbosity),
-    Tree1 = erl_syntax:infix_expr(A1, erl_syntax:operator('--'), A2),
+visit_remote_application({lists, subtract, 2}, F,
+                         [A1, A2], Tree, Env, St0) ->
+    report({Env#env.file,
+            erl_syntax:get_pos(F),
+            "replacing call to `lists:subtract/2' "
+            "with the `--' operator."},
+           [],
+           Env#env.verbosity),
+    Tree1 = erl_syntax:infix_expr(A1,
+                                  erl_syntax:operator('--'),
+                                  A2),
     visit(rewrite(Tree, Tree1), Env, St0);
 %% --- lists:map/2 and lists:filter/2 ---
-visit_remote_application({lists, filter, 2}, F, [A1, A2] = As, Tree,
-                         Env, St0) ->
-    case Env#env.auto_list_comp
-	and (erl_syntax:type(A1) =/= variable)
-	and (get_var_exports(A1) =:= [])
-	and (get_var_exports(A2) =:= []) of
+visit_remote_application({lists, filter, 2}, F,
+                         [A1, A2] = As, Tree, Env, St0) ->
+    case Env#env.auto_list_comp and
+             (erl_syntax:type(A1) =/= variable)
+             and (get_var_exports(A1) =:= [])
+             and (get_var_exports(A2) =:= [])
+        of
         true ->
-            report({Env#env.file, erl_syntax:get_pos(F),
-		    "replacing call to `lists:filter/2' "
-		    "with a list comprehension."},
-		   [], Env#env.verbosity),
+            report({Env#env.file,
+                    erl_syntax:get_pos(F),
+                    "replacing call to `lists:filter/2' with "
+                    "a list comprehension."},
+                   [],
+                   Env#env.verbosity),
             {V, St1} = new_variable(St0),
             G = clone(A2, erl_syntax:generator(V, A2)),
             T = clone(A1, erl_syntax:application(A1, [V])),
             L = erl_syntax:list_comp(V, [G, T]),
             L1 = erl_syntax_lib:annotate_bindings(L, get_env(Tree)),
             visit(rewrite(Tree, L1), Env, St1);
-        false ->
-            visit_application_final(F, As, Tree, St0)
+        false -> visit_application_final(F, As, Tree, St0)
     end;
-visit_remote_application({lists, map, 2}, F, [A1, A2] = As, Tree, Env,
-                         St0) ->
-    case Env#env.auto_list_comp
-	and (erl_syntax:type(A1) =/= variable)
-	and (get_var_exports(A1) =:= [])
-	and (get_var_exports(A2) =:= []) of
+visit_remote_application({lists, map, 2}, F,
+                         [A1, A2] = As, Tree, Env, St0) ->
+    case Env#env.auto_list_comp and
+             (erl_syntax:type(A1) =/= variable)
+             and (get_var_exports(A1) =:= [])
+             and (get_var_exports(A2) =:= [])
+        of
         true ->
-            report({Env#env.file, erl_syntax:get_pos(F),
-		    "replacing call to `lists:map/2' "
-		    "with a list comprehension."},
-		   [], Env#env.verbosity),
+            report({Env#env.file,
+                    erl_syntax:get_pos(F),
+                    "replacing call to `lists:map/2' with "
+                    "a list comprehension."},
+                   [],
+                   Env#env.verbosity),
             {V, St1} = new_variable(St0),
             T = clone(A1, erl_syntax:application(A1, [V])),
             G = clone(A2, erl_syntax:generator(V, A2)),
             L = erl_syntax:list_comp(T, [G]),
             L1 = erl_syntax_lib:annotate_bindings(L, get_env(Tree)),
             visit(rewrite(Tree, L1), Env, St1);
-        false ->
-            visit_application_final(F, As, Tree, St0)
+        false -> visit_application_final(F, As, Tree, St0)
     end;
 %% --- all other functions ---
-visit_remote_application({M, N, A} = Name, F, As, Tree, Env, St) ->
+visit_remote_application({M, N, A} = Name, F, As, Tree,
+                         Env, St) ->
     case is_auto_imported(Name) of
         true ->
             %% We don't remove the qualifier - it might be there for the
@@ -1393,17 +1324,17 @@ visit_remote_application({M, N, A} = Name, F, As, Tree, Env, St) ->
         false ->
             case rename_remote_call(Name, St) of
                 {M1, N1} ->
-                    report({Env#env.file, erl_syntax:get_pos(F),
-			    "updating obsolete call to `~w:~w/~w' "
-			    "to use `~w:~w/~w' instead."},
-			   [M, N, A, M1, N1, A], Env#env.verbosity),
+                    report({Env#env.file,
+                            erl_syntax:get_pos(F),
+                            "updating obsolete call to `~w:~w/~w' "
+                            "to use `~w:~w/~w' instead."},
+                           [M, N, A, M1, N1, A],
+                           Env#env.verbosity),
                     M2 = erl_syntax:atom(M1),
                     N2 = erl_syntax:atom(N1),
                     F1 = erl_syntax:module_qualifier(M2, N2),
-                    revisit_application(rewrite(F, F1), As, Tree, Env,
-                                        St);
-                false ->
-                    visit_application_final(F, As, Tree, St)
+                    revisit_application(rewrite(F, F1), As, Tree, Env, St);
+                false -> visit_application_final(F, As, Tree, St)
             end
     end.
 
@@ -1415,25 +1346,23 @@ auto_expand_import({lists, filter, 2}, _St) -> true;
 auto_expand_import({lists, map, 2}, _St) -> true;
 auto_expand_import(Name, St) ->
     case is_auto_imported(Name) of
-        true ->
-            true;
-        false ->
-            rename_remote_call(Name, St) =/= false
+        true -> true;
+        false -> rename_remote_call(Name, St) =/= false
     end.
 
 visit_list_comp(Tree, Env, St0) ->
     Es = erl_syntax:list_comp_body(Tree),
     {Es1, St1} = visit_list_comp_body(Es, Env, St0),
-    {T, St2} = visit(erl_syntax:list_comp_template(Tree), Env, St1),
+    {T, St2} = visit(erl_syntax:list_comp_template(Tree),
+                     Env,
+                     St1),
     {rewrite(Tree, erl_syntax:list_comp(T, Es1)), St2}.
 
 visit_list_comp_body_join(Env) ->
     fun (E, St0) ->
             case is_generator(E) of
-                true ->
-                    visit_generator(E, Env, St0);
-                false ->
-                    visit_filter(E, Env, St0)
+                true -> visit_generator(E, Env, St0);
+                false -> visit_filter(E, Env, St0)
             end
     end.
 
@@ -1442,8 +1371,7 @@ visit_list_comp_body(Es, Env, St0) ->
 
 %% 'visit_filter' also handles uninteresting generators.
 
-visit_filter(E, Env, St0) ->
-    visit(E, Env, St0).
+visit_filter(E, Env, St0) -> visit(E, Env, St0).
 
 %% "interesting" generators have the form V <- [V || ...]; this can be
 %% unfolded as long as no bindings become erroneously shadowed.
@@ -1457,29 +1385,30 @@ visit_generator(G, Env, St0) ->
                 list_comp ->
                     T = erl_syntax:list_comp_template(B),
                     case erl_syntax:type(T) of
-                        variable ->
-                            visit_generator_1(G, Env, St0);
-                        _ ->
-                            visit_filter(G, Env, St0)
+                        variable -> visit_generator_1(G, Env, St0);
+                        _ -> visit_filter(G, Env, St0)
                     end;
-                _ ->
-                    visit_filter(G, Env, St0)
+                _ -> visit_filter(G, Env, St0)
             end;
-        _ ->
-            visit_filter(G, Env, St0)
+        _ -> visit_filter(G, Env, St0)
     end.
 
 visit_generator_1(G, Env, St0) ->
-    recommend({Env#env.file, erl_syntax:get_pos(G),
-	       "unfold that this nested list comprehension can be unfolded "
-	       "by hand to get better efficiency."},
-	      [], Env#env.verbosity),
+    recommend({Env#env.file,
+               erl_syntax:get_pos(G),
+               "unfold that this nested list comprehension "
+               "can be unfolded by hand to get better "
+               "efficiency."},
+              [],
+              Env#env.verbosity),
     visit_filter(G, Env, St0).
 
 visit_match_expr(Tree, Env, St0) ->
     %% We do not visit the pattern (for now, anyway).
     P = erl_syntax:match_expr_pattern(Tree),
-    {B, St1} = visit(erl_syntax:match_expr_body(Tree), Env, St0),
+    {B, St1} = visit(erl_syntax:match_expr_body(Tree),
+                     Env,
+                     St0),
     case erl_syntax:type(P) of
         tuple ->
             Ps = erl_syntax:tuple_elements(P),
@@ -1492,27 +1421,22 @@ visit_match_expr(Tree, Env, St0) ->
                             Xs = get_var_exports(B),
                             case ordsets:intersection(Vs, Xs) of
                                 [] ->
-                                    visit_match_body(Ps, P, B, Tree,
-                                                     Env, St1);
+                                    visit_match_body(Ps, P, B, Tree, Env, St1);
                                 _ ->
-                                    visit_match_expr_final(P, B, Tree,
-                                                           Env, St1)
+                                    visit_match_expr_final(P, B, Tree, Env, St1)
                             end;
-                        false ->
-                            visit_match_expr_final(P, B, Tree, Env, St1)
+                        false -> visit_match_expr_final(P, B, Tree, Env, St1)
                     end;
-                false ->
-                    visit_match_expr_final(P, B, Tree, Env, St1)
+                false -> visit_match_expr_final(P, B, Tree, Env, St1)
             end;
-        _  ->
-            visit_match_expr_final(P, B, Tree, Env, St1)
+        _ -> visit_match_expr_final(P, B, Tree, Env, St1)
     end.
 
 visit_match_expr_final(P, B, Tree, _Env, St0) ->
     {rewrite(Tree, erl_syntax:match_expr(P, B)), St0}.
 
-visit_match_body(_Ps, P, B, Tree, #env{auto_export_vars = false} = Env,
-                 St0) ->
+visit_match_body(_Ps, P, B, Tree,
+                 #env{auto_export_vars = false} = Env, St0) ->
     visit_match_expr_final(P, B, Tree, Env, St0);
 visit_match_body(Ps, P, B, Tree, Env, St0) ->
     case erl_syntax:type(B) of
@@ -1521,37 +1445,37 @@ visit_match_body(Ps, P, B, Tree, Env, St0) ->
             case multival_clauses(Cs, length(Ps), Ps) of
                 {true, Cs1} ->
                     report_export_vars(Env#env.file,
-				       erl_syntax:get_pos(B),
-				       "case", Env#env.verbosity),
+                                       erl_syntax:get_pos(B),
+                                       "case",
+                                       Env#env.verbosity),
                     A = erl_syntax:case_expr_argument(B),
                     Tree1 = erl_syntax:case_expr(A, Cs1),
                     {rewrite(Tree, Tree1), St0};
-                false ->
-                    visit_match_expr_final(P, B, Tree, Env, St0)
+                false -> visit_match_expr_final(P, B, Tree, Env, St0)
             end;
         if_expr ->
             Cs = erl_syntax:if_expr_clauses(B),
             case multival_clauses(Cs, length(Ps), Ps) of
                 {true, Cs1} ->
                     report_export_vars(Env#env.file,
-				       erl_syntax:get_pos(B),
-				       "if", Env#env.verbosity),
+                                       erl_syntax:get_pos(B),
+                                       "if",
+                                       Env#env.verbosity),
                     Tree1 = erl_syntax:if_expr(Cs1),
                     {rewrite(Tree, Tree1), St0};
-                false ->
-                    visit_match_expr_final(P, B, Tree, Env, St0)
+                false -> visit_match_expr_final(P, B, Tree, Env, St0)
             end;
         cond_expr ->
             Cs = erl_syntax:cond_expr_clauses(B),
             case multival_clauses(Cs, length(Ps), Ps) of
                 {true, Cs1} ->
                     report_export_vars(Env#env.file,
-				       erl_syntax:get_pos(B),
-				       "cond", Env#env.verbosity),
+                                       erl_syntax:get_pos(B),
+                                       "cond",
+                                       Env#env.verbosity),
                     Tree1 = erl_syntax:cond_expr(Cs1),
                     {rewrite(Tree, Tree1), St0};
-                false ->
-                    visit_match_expr_final(P, B, Tree, Env, St0)
+                false -> visit_match_expr_final(P, B, Tree, Env, St0)
             end;
         receive_expr ->
             %% Handle the timeout case as an extra clause.
@@ -1561,17 +1485,16 @@ visit_match_body(Ps, P, B, Tree, Env, St0) ->
             case multival_clauses([C | Cs], length(Ps), Ps) of
                 {true, [C1 | Cs1]} ->
                     report_export_vars(Env#env.file,
-				       erl_syntax:get_pos(B),
-				       "receive", Env#env.verbosity),
+                                       erl_syntax:get_pos(B),
+                                       "receive",
+                                       Env#env.verbosity),
                     T = erl_syntax:receive_expr_timeout(B),
                     As1 = erl_syntax:clause_body(C1),
                     Tree1 = erl_syntax:receive_expr(Cs1, T, As1),
                     {rewrite(Tree, Tree1), St0};
-                false ->
-                    visit_match_expr_final(P, B, Tree, Env, St0)
+                false -> visit_match_expr_final(P, B, Tree, Env, St0)
             end;
-        _ ->
-            visit_match_expr_final(P, B, Tree, Env, St0)
+        _ -> visit_match_expr_final(P, B, Tree, Env, St0)
     end.
 
 multival_clauses(Cs, N, Vs) ->
@@ -1579,23 +1502,20 @@ multival_clauses(Cs, N, Vs) ->
 
 multival_clauses([C | Cs], N, Vs, Cs1) ->
     case erl_syntax:clause_body(C) of
-        [] ->
-            false;
+        [] -> false;
         Es ->
             E = lists:last(Es),
             case erl_syntax:type(E) of
                 tuple ->
                     Ts = erl_syntax:tuple_elements(E),
                     if length(Ts) =:= N ->
-                            Bs = make_matches(E, Vs, Ts),
-                            Es1 = replace_last(Es, Bs),
-                            Ps = erl_syntax:clause_patterns(C),
-                            G = erl_syntax:clause_guard(C),
-                            C1 = erl_syntax:clause(Ps, G, Es1),
-                            multival_clauses(Cs, N, Vs,
-                                             [rewrite(C, C1) | Cs1]);
-                       true ->
-                            false
+                           Bs = make_matches(E, Vs, Ts),
+                           Es1 = replace_last(Es, Bs),
+                           Ps = erl_syntax:clause_patterns(C),
+                           G = erl_syntax:clause_guard(C),
+                           C1 = erl_syntax:clause(Ps, G, Es1),
+                           multival_clauses(Cs, N, Vs, [rewrite(C, C1) | Cs1]);
+                       true -> false
                     end;
                 _ ->
                     case erl_syntax_lib:is_fail_expr(E) of
@@ -1603,16 +1523,13 @@ multival_clauses([C | Cs], N, Vs, Cs1) ->
                             %% We must add dummy bindings here so we
                             %% don't introduce compilation errors due to
                             %% "unsafe" variable exports.
-                            Bs = make_matches(Vs,
-                                              erl_syntax:atom(false)),
+                            Bs = make_matches(Vs, erl_syntax:atom(false)),
                             Es1 = replace_last(Es, Bs ++ [E]),
                             Ps = erl_syntax:clause_patterns(C),
                             G = erl_syntax:clause_guard(C),
                             C1 = erl_syntax:clause(Ps, G, Es1),
-                            multival_clauses(Cs, N, Vs,
-                                             [rewrite(C, C1) | Cs1]);
-                        false ->
-                            false
+                            multival_clauses(Cs, N, Vs, [rewrite(C, C1) | Cs1]);
+                        false -> false
                     end
             end
     end;
@@ -1621,58 +1538,86 @@ multival_clauses([], _N, _Vs, Cs) ->
 
 make_matches(E, Vs, Ts) ->
     case make_matches(Vs, Ts) of
-        [] ->
-            [];
+        [] -> [];
         [B | Bs] ->
-            [rewrite(E, B) | Bs]    % preserve comments on E (but not B)
+            [rewrite(E, B)
+             | Bs]    % preserve comments on E (but not B)
     end.
 
 make_matches([V | Vs], [T | Ts]) ->
     [erl_syntax:match_expr(V, T) | make_matches(Vs, Ts)];
 make_matches([V | Vs], T) when T =/= [] ->
     [erl_syntax:match_expr(V, T) | make_matches(Vs, T)];
-make_matches([], _) ->
-    [].
+make_matches([], _) -> [].
 
 rename_remote_call(F, St) ->
     case dict:find(F, St#st.rename) of
-        error ->
-            rename_remote_call_1(F);
+        error -> rename_remote_call_1(F);
         {ok, F1} -> F1
     end.
 
--spec rename_remote_call_1(mfa()) -> {atom(), atom()} | 'false'.
+-spec rename_remote_call_1(mfa()) -> {atom(), atom()} |
+                                     false.
 
-rename_remote_call_1({dict, dict_to_list, 1}) -> {dict, to_list};
-rename_remote_call_1({dict, list_to_dict, 1}) -> {dict, from_list};
-rename_remote_call_1({erl_eval, arg_list, 2}) -> {erl_eval, expr_list};
-rename_remote_call_1({erl_eval, arg_list, 3}) -> {erl_eval, expr_list};
-rename_remote_call_1({erl_eval, seq, 2}) -> {erl_eval, exprs};
-rename_remote_call_1({erl_eval, seq, 3}) -> {erl_eval, exprs};
-rename_remote_call_1({erl_pp, seq, 1}) -> {erl_eval, seq};
-rename_remote_call_1({erl_pp, seq, 2}) -> {erl_eval, seq};
-rename_remote_call_1({erlang, info, 1}) -> {erlang, system_info};
-rename_remote_call_1({io, parse_erl_seq, 1}) -> {io, parse_erl_exprs};
-rename_remote_call_1({io, parse_erl_seq, 2}) -> {io, parse_erl_exprs};
-rename_remote_call_1({io, parse_erl_seq, 3}) -> {io, parse_erl_exprs};
-rename_remote_call_1({io, scan_erl_seq, 1}) -> {io, scan_erl_exprs};
-rename_remote_call_1({io, scan_erl_seq, 2}) -> {io, scan_erl_exprs};
-rename_remote_call_1({io, scan_erl_seq, 3}) -> {io, scan_erl_exprs};
-rename_remote_call_1({io_lib, reserved_word, 1}) -> {erl_scan, reserved_word};
-rename_remote_call_1({io_lib, scan, 1}) -> {erl_scan, string};
-rename_remote_call_1({io_lib, scan, 2}) -> {erl_scan, string};
-rename_remote_call_1({io_lib, scan, 3}) -> {erl_scan, tokens};
-rename_remote_call_1({orddict, dict_to_list, 1}) -> {orddict, to_list};
-rename_remote_call_1({orddict, list_to_dict, 1}) -> {orddict, from_list};
-rename_remote_call_1({ordsets, list_to_set, 1}) -> {ordsets, from_list};
-rename_remote_call_1({ordsets, new_set, 0}) -> {ordsets, new};
-rename_remote_call_1({ordsets, set_to_list, 1}) -> {ordsets, to_list};
-rename_remote_call_1({ordsets, subset, 2}) -> {ordsets, is_subset};
-rename_remote_call_1({sets, list_to_set, 1}) -> {sets, from_list};
+rename_remote_call_1({dict, dict_to_list, 1}) ->
+    {dict, to_list};
+rename_remote_call_1({dict, list_to_dict, 1}) ->
+    {dict, from_list};
+rename_remote_call_1({erl_eval, arg_list, 2}) ->
+    {erl_eval, expr_list};
+rename_remote_call_1({erl_eval, arg_list, 3}) ->
+    {erl_eval, expr_list};
+rename_remote_call_1({erl_eval, seq, 2}) ->
+    {erl_eval, exprs};
+rename_remote_call_1({erl_eval, seq, 3}) ->
+    {erl_eval, exprs};
+rename_remote_call_1({erl_pp, seq, 1}) ->
+    {erl_eval, seq};
+rename_remote_call_1({erl_pp, seq, 2}) ->
+    {erl_eval, seq};
+rename_remote_call_1({erlang, info, 1}) ->
+    {erlang, system_info};
+rename_remote_call_1({io, parse_erl_seq, 1}) ->
+    {io, parse_erl_exprs};
+rename_remote_call_1({io, parse_erl_seq, 2}) ->
+    {io, parse_erl_exprs};
+rename_remote_call_1({io, parse_erl_seq, 3}) ->
+    {io, parse_erl_exprs};
+rename_remote_call_1({io, scan_erl_seq, 1}) ->
+    {io, scan_erl_exprs};
+rename_remote_call_1({io, scan_erl_seq, 2}) ->
+    {io, scan_erl_exprs};
+rename_remote_call_1({io, scan_erl_seq, 3}) ->
+    {io, scan_erl_exprs};
+rename_remote_call_1({io_lib, reserved_word, 1}) ->
+    {erl_scan, reserved_word};
+rename_remote_call_1({io_lib, scan, 1}) ->
+    {erl_scan, string};
+rename_remote_call_1({io_lib, scan, 2}) ->
+    {erl_scan, string};
+rename_remote_call_1({io_lib, scan, 3}) ->
+    {erl_scan, tokens};
+rename_remote_call_1({orddict, dict_to_list, 1}) ->
+    {orddict, to_list};
+rename_remote_call_1({orddict, list_to_dict, 1}) ->
+    {orddict, from_list};
+rename_remote_call_1({ordsets, list_to_set, 1}) ->
+    {ordsets, from_list};
+rename_remote_call_1({ordsets, new_set, 0}) ->
+    {ordsets, new};
+rename_remote_call_1({ordsets, set_to_list, 1}) ->
+    {ordsets, to_list};
+rename_remote_call_1({ordsets, subset, 2}) ->
+    {ordsets, is_subset};
+rename_remote_call_1({sets, list_to_set, 1}) ->
+    {sets, from_list};
 rename_remote_call_1({sets, new_set, 0}) -> {sets, new};
-rename_remote_call_1({sets, set_to_list, 1}) -> {sets, to_list};
-rename_remote_call_1({sets, subset, 2}) -> {sets, is_subset};
-rename_remote_call_1({string, index, 2}) -> {string, str};
+rename_remote_call_1({sets, set_to_list, 1}) ->
+    {sets, to_list};
+rename_remote_call_1({sets, subset, 2}) ->
+    {sets, is_subset};
+rename_remote_call_1({string, index, 2}) ->
+    {string, str};
 rename_remote_call_1({unix, cmd, 1}) -> {os, cmd};
 rename_remote_call_1(_) -> false.
 
@@ -1714,41 +1659,39 @@ reverse_guard_test(is_record, 2) -> record;
 reverse_guard_test(is_record, 3) -> record;
 reverse_guard_test(N, _A) -> N.
 
-
 %% =====================================================================
 %% Utility functions
 
-is_remote_name({M,F,A}) when is_atom(M), is_atom(F), is_integer(A) -> true;
+is_remote_name({M, F, A})
+    when is_atom(M), is_atom(F), is_integer(A) ->
+    true;
 is_remote_name(_) -> false.
 
-is_atom_pair({M,F}) when is_atom(M), is_atom(F) -> true;
+is_atom_pair({M, F}) when is_atom(M), is_atom(F) ->
+    true;
 is_atom_pair(_) -> false.
 
-replace_last([_E], Xs) ->
-    Xs;
+replace_last([_E], Xs) -> Xs;
 replace_last([E | Es], Xs) ->
     [E | replace_last(Es, Xs)].
 
-is_generator(E) ->
-    erl_syntax:type(E) =:= generator.
+is_generator(E) -> erl_syntax:type(E) =:= generator.
 
-is_variable(E) ->
-    erl_syntax:type(E) =:= variable.
+is_variable(E) -> erl_syntax:type(E) =:= variable.
 
 new_variables(N, St0) when N > 0 ->
     {V, St1} = new_variable(St0),
     {Vs, St2} = new_variables(N - 1, St1),
     {[V | Vs], St2};
-new_variables(0, St) ->
-    {[], St}.
+new_variables(0, St) -> {[], St}.
 
 new_variable(St0) ->
-    Fun = fun (N) ->
-                  list_to_atom("V" ++ integer_to_list(N))
+    Fun = fun (N) -> list_to_atom("V" ++ integer_to_list(N))
           end,
     Vs = St0#st.vars,
     {Name, N} = new_name(St0#st.varc, Fun, Vs),
-    St1 = St0#st{varc = N + 1, vars = sets:add_element(Name, Vs)},
+    St1 = St0#st{varc = N + 1,
+                 vars = sets:add_element(Name, Vs)},
     {erl_syntax:variable(Name), St1}.
 
 new_fname({F, A}, St0) ->
@@ -1763,28 +1706,21 @@ new_fname({F, A}, St0) ->
 new_name(N, F, Set) ->
     Name = F(N),
     case sets:is_element(Name, Set) of
-        true ->
-            new_name(N + 1, F, Set);
-        false ->
-            {Name, N}
+        true -> new_name(N + 1, F, Set);
+        false -> {Name, N}
     end.
 
-is_imported(F, Env) ->
-    dict:is_key(F, Env#env.imports).
+is_imported(F, Env) -> dict:is_key(F, Env#env.imports).
 
 is_auto_imported({erlang, N, A}) ->
     is_auto_imported({N, A});
-is_auto_imported({_, _N, _A}) ->
-    false;
-is_auto_imported({N, A}) ->
-    erl_internal:bif(N, A).
+is_auto_imported({_, _N, _A}) -> false;
+is_auto_imported({N, A}) -> erl_internal:bif(N, A).
 
 is_nonlocal(N, Env) ->
     case is_imported(N, Env) of
-        true ->
-            true;
-        false ->
-            is_auto_imported(N)
+        true -> true;
+        false -> is_auto_imported(N)
     end.
 
 get_var_exports(Node) ->
@@ -1803,22 +1739,17 @@ get_free_vars_1([]) -> [].
 
 filename([C | T]) when is_integer(C), C > 0 ->
     [C | filename(T)];
-filename([H|T]) ->
-    filename(H) ++ filename(T);
-filename([]) ->
-    [];
-filename(N) when is_atom(N) ->
-    atom_to_list(N);
+filename([H | T]) -> filename(H) ++ filename(T);
+filename([]) -> [];
+filename(N) when is_atom(N) -> atom_to_list(N);
 filename(N) ->
     report_error("bad filename: `~P'.", [N, 25]),
     exit(error).
 
 get_env(Tree) ->
     case lists:keyfind(env, 1, erl_syntax:get_ann(Tree)) of
-        {env, Env} ->
-            Env;
-        _ ->
-            []
+        {env, Env} -> Env;
+        _ -> []
     end.
 
 rewrite(Source, Target) ->
@@ -1827,88 +1758,75 @@ rewrite(Source, Target) ->
 clone(Source, Target) ->
     erl_syntax:copy_pos(Source, Target).
 
-
 %% =====================================================================
 %% Reporting
 
 report_export_vars(F, L, Type, Opts) ->
-    report({F, L, "rewrote ~s-expression to export variables."},
-	   [Type], Opts).
+    report({F,
+            L,
+            "rewrote ~s-expression to export variables."},
+           [Type],
+           Opts).
 
 error_read_file(Name) ->
-    report_error("error reading file `~ts'.", [filename(Name)]).
-
-error_write_file(Name) ->
-    report_error("error writing to file `~ts'.", [filename(Name)]).
-
-error_backup_file(Name) ->
-    report_error("could not create backup of file `~ts'.",
+    report_error("error reading file `~ts'.",
                  [filename(Name)]).
 
-error_open_output(Name) ->
-    report_error("cannot open file `~ts' for output.", [filename(Name)]).
-
 verbosity(Opts) ->
-    case proplists:get_bool(quiet, Opts) of 
+    case proplists:get_bool(quiet, Opts) of
         true -> 0;
         false ->
             case proplists:get_value(verbose, Opts) of
                 true -> 2;
-                N when is_integer(N) -> N; 
+                N when is_integer(N) -> N;
                 _ -> 1
             end
     end.
 
-report_error(D) ->
-    report_error(D, []).
-    
+report_error(D) -> report_error(D, []).
+
 report_error({F, L, D}, Vs) ->
     report({F, L, {error, D}}, Vs);
-report_error(D, Vs) ->
-    report({error, D}, Vs).
+report_error(D, Vs) -> report({error, D}, Vs).
 
 %% warn(D, N) ->
 %%     warn(D, [], N).
 
 warn({F, L, D}, Vs, N) ->
     report({F, L, {warning, D}}, Vs, N);
-warn(D, Vs, N) ->
-    report({warning, D}, Vs, N).
+warn(D, Vs, N) -> report({warning, D}, Vs, N).
 
-recommend(D, Vs, N) ->
-    report({recommend, D}, Vs, N).
+recommend(D, Vs, N) -> report({recommend, D}, Vs, N).
 
-verbose(D, Vs, N) ->
-    report(2, D, Vs, N).
+verbose(D, Vs, N) -> report(2, D, Vs, N).
 
-report(D, Vs) ->
-    report(D, Vs, 1).
+report(D, Vs) -> report(D, Vs, 1).
 
-report(D, Vs, N) ->
-    report(1, D, Vs, N).
+report(D, Vs, N) -> report(1, D, Vs, N).
 
-report(Level, _D, _Vs, N) when is_integer(N), N < Level ->
+report(Level, _D, _Vs, N)
+    when is_integer(N), N < Level ->
     ok;
 report(_Level, D, Vs, N) when is_integer(N) ->
     io:put_chars(format(D, Vs));
 report(Level, D, Vs, Options) when is_list(Options) ->
     report(Level, D, Vs, verbosity(Options)).
 
-format({error, D}, Vs) ->
-    ["error: ", format(D, Vs)];
+format({error, D}, Vs) -> ["error: ", format(D, Vs)];
 format({warning, D}, Vs) ->
     ["warning: ", format(D, Vs)];
 format({recommend, D}, Vs) ->
     ["recommendation: ", format(D, Vs)];
 format({"", L, D}, Vs) when is_integer(L), L > 0 ->
     [io_lib:fwrite("~w: ", [L]), format(D, Vs)];
-format({"", _L, D}, Vs) ->
-    format(D, Vs);
+format({"", _L, D}, Vs) -> format(D, Vs);
 format({F, L, D}, Vs) when is_integer(L), L > 0 ->
-    [io_lib:fwrite("~ts:~w: ", [filename(F), L]), format(D, Vs)];
+    [io_lib:fwrite("~ts:~w: ", [filename(F), L]),
+     format(D, Vs)];
 format({F, _L, D}, Vs) ->
     [io_lib:fwrite("~ts: ", [filename(F)]), format(D, Vs)];
 format(S, Vs) when is_list(S) ->
     [io_lib:fwrite(S, Vs), $\n].
 
 %% =====================================================================
+

--- a/src/erl_tidy_prv_fmt.erl
+++ b/src/erl_tidy_prv_fmt.erl
@@ -69,5 +69,7 @@ fmt_opts() ->
      {no_imports, undefined, "no_imports", {boolean, false},
       "all import statements will be removed "
       "and calls to imported functions will be expanded "
-      "to explicit remote calls"}
+      "to explicit remote calls"},
+     {backups, undefined, "backups", {boolean, true},
+      "keep backups of your original code safely stored"}
     ].

--- a/src/erl_tidy_prv_fmt.erl
+++ b/src/erl_tidy_prv_fmt.erl
@@ -2,72 +2,108 @@
 
 -behaviour(provider).
 
--export([init/1,
-         do/1,
-         format_error/1]).
+-export([do/1, format_error/1, init/1]).
 
 -define(PROVIDER, fmt).
+
 -define(DEPS, [app_discovery]).
 
 %% ===================================================================
 %% Public API
 %% ===================================================================
 
--spec init(rebar_state:state()) -> {ok, rebar_state:state()}.
+-spec init(rebar_state:state()) -> {ok,
+                                    rebar_state:state()}.
+
 init(State) ->
-    State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
-                                                               {module, ?MODULE},
-                                                               {bare, false},
-                                                               {deps, ?DEPS},
-                                                               {example, "rebar3 fmt"},
-                                                               {short_desc, "format modules."},
-                                                               {desc, ""},
-                                                               {opts, fmt_opts()}])),
+    State1 = rebar_state:add_provider(State,
+                                      providers:create([{name, ?PROVIDER},
+                                                        {module, ?MODULE},
+                                                        {bare, false},
+                                                        {deps, ?DEPS},
+                                                        {example, "rebar3 fmt"},
+                                                        {short_desc,
+                                                         "format modules."},
+                                                        {desc, ""},
+                                                        {opts, fmt_opts()}])),
     {ok, State1}.
 
--spec do(rebar_state:state()) -> {ok, rebar_state:state()}.
+-spec do(rebar_state:state()) -> {ok,
+                                  rebar_state:state()}.
+
 do(State) ->
     ConfigFileOpts = rebar_state:get(State, fmt_opts, []),
     {CliOpts, _} = rebar_state:command_parsed_args(State),
     % CLI opts take precedence over config file
     Opts = rebar_utils:tup_umerge(ConfigFileOpts, CliOpts),
-
     ProjectApps = rebar_state:project_apps(State),
     format_apps(Opts, ProjectApps),
     {ok, State}.
 
 -spec format_error(any()) -> iolist().
-format_error(Reason) ->
-    io_lib:format("~p", [Reason]).
+
+format_error(Reason) -> io_lib:format("~p", [Reason]).
 
 format_apps(Opts, Apps) ->
-    lists:foreach(fun(AppInfo) ->
-                          SrcDir = filename:join(rebar_app_info:dir(AppInfo), "src"),
-                          rebar_log:log(info, "Formating ~s...", [rebar_app_info:name(AppInfo)]),
+    lists:foreach(fun (AppInfo) ->
+                          SrcDir = filename:join(rebar_app_info:dir(AppInfo),
+                                                 "src"),
+                          rebar_log:log(info,
+                                        "Formating FOOBAR ~s...",
+                                        [rebar_app_info:name(AppInfo)]),
                           erl_tidy:dir(SrcDir, Opts)
-                  end, Apps).
+                  end,
+                  Apps).
 
 fmt_opts() ->
-    [{test, undefined, "test", {boolean, false},
+    [{test,
+      undefined,
+      "test",
+      {boolean, false},
       "do not modify files"},
-     {verbose, undefined, "verbose", {boolean, true},
-      "progress messages will be output while the program is running, "
-      "unless the `quiet' option is set"},
-     {quiet, undefined, "quiet", {boolean, false},
-      "all information messages and warning messages will be suppressed"},
-     {auto_list_comp, undefined, "auto_list_comp", {boolean, false},
-      "calls to `lists:map/2' and `lists:filter/2' will be rewritten "
-      "using list comprehensions"},
-     {keep_unused, undefined, "keep_unused", {boolean, false},
-      "unused functions will not be removed from the code"},
-     {new_guard_tests, undefined, "new_guard_tests", {boolean, true},
-      "guard tests will be updated to use the new names, "
-      "e.g. `is_integer(X)' instead of `integer(X)'"},
-     {old_guard_tests, undefined, "old_guard_tests", {boolean, false},
-      "guard tests will be changed to use the old names "
-      "instead of the new ones, e.g. `integer(X)' instead of `is_integer(X)'"},
-     {no_imports, undefined, "no_imports", {boolean, false},
+     {verbose,
+      undefined,
+      "verbose",
+      {boolean, true},
+      "progress messages will be output while "
+      "the program is running, unless the `quiet' "
+      "option is set"},
+     {quiet,
+      undefined,
+      "quiet",
+      {boolean, false},
+      "all information messages and warning "
+      "messages will be suppressed"},
+     {auto_list_comp,
+      undefined,
+      "auto_list_comp",
+      {boolean, false},
+      "calls to `lists:map/2' and `lists:filter/2' "
+      "will be rewritten using list comprehensions"},
+     {keep_unused,
+      undefined,
+      "keep_unused",
+      {boolean, false},
+      "unused functions will not be removed "
+      "from the code"},
+     {new_guard_tests,
+      undefined,
+      "new_guard_tests",
+      {boolean, true},
+      "guard tests will be updated to use the "
+      "new names, e.g. `is_integer(X)' instead "
+      "of `integer(X)'"},
+     {old_guard_tests,
+      undefined,
+      "old_guard_tests",
+      {boolean, false},
+      "guard tests will be changed to use the "
+      "old names instead of the new ones, e.g. "
+      "`integer(X)' instead of `is_integer(X)'"},
+     {no_imports,
+      undefined,
+      "no_imports",
+      {boolean, false},
       "all import statements will be removed "
-      "and calls to imported functions will be expanded "
-      "to explicit remote calls"}
-    ].
+      "and calls to imported functions will "
+      "be expanded to explicit remote calls"}].


### PR DESCRIPTION
Exposes the `backups` boolean option as a stdin argument, allowing the user to 
specify whether or not to create backups of files that are modified.

Moderately tested, but not extensively. This is a simple change that relies on 
existing core logic without introducing new logic.

Really just a matter of adding a new stdin argument `fmt_opts` array in the 
`erl_tidy_prv_fmt.erl` module.

For folks who wanna live life dangerously, they can now run `erl_tidy` without
backups filling up their directories.